### PR TITLE
Feat/aboutScreen

### DIFF
--- a/src/domain/Menu.cpp
+++ b/src/domain/Menu.cpp
@@ -1,5 +1,6 @@
 #include "interfaces/Menu.hpp"
 #include "common.h"
+#include <vector>
 #include <iostream>
 
 void Menu::init()
@@ -164,19 +165,41 @@ void Menu::showAbout()
     if (!windowPtr)
         return;
 
-    sf::Text aboutText;
-    aboutText.setFont(*font);
-    aboutText.setString("Sobre o Jogo:\n\nDesenvolvedores: Seu Nome\nDescricao: Jogo Exemplo.");
-    aboutText.setCharacterSize(24);
-    aboutText.setFillColor(sf::Color::White);
-    aboutText.setPosition(100, 100);
+    sf::Text infoText;
+    infoText.setFont(*font);
+    infoText.setCharacterSize(15);
+    infoText.setFillColor(sf::Color::White);
+    
+    std::string aboutText = 
+        "Game Version 1.0\n"
+        "Developed by\n\n\n"
+        "Andriel Vinicius\n\n"
+        "   Responsible for developed key game functions, optimizing performance,\n"
+        "   modularizing code, and enhancing the game's audiovisual aspects\n"
+        "\n\n"
+        "Flawbert Lorran\n\n"
+        "   Focused on the development of audiovisual elements\n"
+        "\n\n"
+        "Murilo Costa\n\n"
+        "   Developed key game functions and contributed to code modularization\n"
+        "   and performance optimization.\n";
+
+    infoText.setString(aboutText);
+    infoText.setPosition(100.f, 200.f);
+
+    sf::Text exitText;
+    exitText.setFont(*font);
+    exitText.setCharacterSize(18);
+    exitText.setFillColor(sf::Color::White);
+    exitText.setString("Press `Q` to return");
+    exitText.setPosition(420.f, 600.f);
 
     while (windowPtr->isOpen())
     {
         sf::Event event;
         while (windowPtr->pollEvent(event))
         {
-            if (event.type == sf::Event::Closed || (sf::Keyboard::isKeyPressed(sf::Keyboard::Q)))
+            if (event.type == sf::Event::Closed || sf::Keyboard::isKeyPressed(sf::Keyboard::Q))
             {
                 return;
             }
@@ -184,7 +207,8 @@ void Menu::showAbout()
 
         windowPtr->clear();
         windowPtr->draw(*bg);
-        windowPtr->draw(aboutText);
+        windowPtr->draw(infoText);
+        windowPtr->draw(exitText);
         windowPtr->display();
     }
 }

--- a/src/domain/Menu.cpp
+++ b/src/domain/Menu.cpp
@@ -158,17 +158,11 @@ bool Menu::run()
     return true;
 }
 
-void Menu::showAbout()  // RESOLVER PROBLEMA DA TEXTURA DA IMAGEM DE FUNDO 
+void Menu::showAbout()
 {
     auto windowPtr = window.lock();
     if (!windowPtr)
         return;
-
-    if (!(this->image->loadFromFile(MENU_IMAGE)))
-    {
-        std::cout << "Can't load menu image :( \n";
-    };
-    sf::Texture bg = this->bg->setTexture(*image);
 
     sf::Text aboutText;
     aboutText.setFont(*font);
@@ -189,6 +183,7 @@ void Menu::showAbout()  // RESOLVER PROBLEMA DA TEXTURA DA IMAGEM DE FUNDO
         }
 
         windowPtr->clear();
+        windowPtr->draw(*bg);
         windowPtr->draw(aboutText);
         windowPtr->display();
     }

--- a/src/domain/Menu.cpp
+++ b/src/domain/Menu.cpp
@@ -148,8 +148,8 @@ bool Menu::run()
         case MenuActions::START:
             return false;
         case MenuActions::ABOUT:
-            showAbout(); // Mostra a tela de "Sobre"
-            break; // Retorna ao menu principal após mostrar o "Sobre"
+            showAbout();
+            break;
         case MenuActions::EXIT:
             windowPtr->close();
             break;

--- a/src/domain/Menu.cpp
+++ b/src/domain/Menu.cpp
@@ -1,6 +1,5 @@
 #include "interfaces/Menu.hpp"
 #include "common.h"
-#include <vector>
 #include <iostream>
 
 void Menu::init()

--- a/src/domain/Menu.cpp
+++ b/src/domain/Menu.cpp
@@ -174,15 +174,14 @@ void Menu::showAbout()
         "Game Version 1.0\n"
         "Developed by\n\n\n"
         "Andriel Vinicius\n\n"
-        "   Responsible for developed key game functions, optimizing performance,\n"
-        "   modularizing code, and enhancing the game's audiovisual aspects\n"
+        "   Performance Optimizer, Modularizer, Game Designer, Sound Engineer\n"
+        "   & Developer\n"
         "\n\n"
         "Flawbert Lorran\n\n"
-        "   Focused on the development of audiovisual elements\n"
+        "   Game Designer, Sound Engineer & Developer\n"
         "\n\n"
         "Murilo Costa\n\n"
-        "   Developed key game functions and contributed to code modularization\n"
-        "   and performance optimization.\n";
+        "   Performance Optimizer, Modularizer & Developer\n";
 
     infoText.setString(aboutText);
     infoText.setPosition(100.f, 200.f);

--- a/src/domain/Menu.cpp
+++ b/src/domain/Menu.cpp
@@ -99,6 +99,10 @@ MenuActions Menu::handleActions()
             // If user enters on start option, it should start the game
             if (this->current == 0)
                 return MenuActions::START;
+            
+            // If user enters on start option, it should show the about
+            if (this->current == (int)this->optionsTexts->size() - 2)
+                return MenuActions::ABOUT;
 
             // If user enters on quit option (the last one)
             if (this->current == (int)this->optionsTexts->size() - 1)
@@ -142,9 +146,9 @@ bool Menu::run()
         {
         case MenuActions::START:
             return false;
-        case MenuActions::NONE:
         case MenuActions::ABOUT:
-            return true;
+            showAbout(); // Mostra a tela de "Sobre"
+            break; // Retorna ao menu principal após mostrar o "Sobre"
         case MenuActions::EXIT:
             windowPtr->close();
             break;
@@ -152,4 +156,40 @@ bool Menu::run()
     }
     // if nothing happens, stays on menu
     return true;
+}
+
+void Menu::showAbout()  // RESOLVER PROBLEMA DA TEXTURA DA IMAGEM DE FUNDO 
+{
+    auto windowPtr = window.lock();
+    if (!windowPtr)
+        return;
+
+    if (!(this->image->loadFromFile(MENU_IMAGE)))
+    {
+        std::cout << "Can't load menu image :( \n";
+    };
+    sf::Texture bg = this->bg->setTexture(*image);
+
+    sf::Text aboutText;
+    aboutText.setFont(*font);
+    aboutText.setString("Sobre o Jogo:\n\nDesenvolvedores: Seu Nome\nDescricao: Jogo Exemplo.");
+    aboutText.setCharacterSize(24);
+    aboutText.setFillColor(sf::Color::White);
+    aboutText.setPosition(100, 100);
+
+    while (windowPtr->isOpen())
+    {
+        sf::Event event;
+        while (windowPtr->pollEvent(event))
+        {
+            if (event.type == sf::Event::Closed || (sf::Keyboard::isKeyPressed(sf::Keyboard::Q)))
+            {
+                return;
+            }
+        }
+
+        windowPtr->clear();
+        windowPtr->draw(aboutText);
+        windowPtr->display();
+    }
 }

--- a/src/domain/interfaces/Menu.hpp
+++ b/src/domain/interfaces/Menu.hpp
@@ -26,6 +26,8 @@ private:
     std::unique_ptr<std::vector<sf::Vector2f>> optionsCoords;
     std::unique_ptr<std::vector<sf::Text>> optionsTexts;
     std::unique_ptr<std::vector<std::size_t>> optionsSize;
+    /// @brief Show the About Screen with the infos about Us, the developers
+    void showAbout();
 
 protected:
     /// @brief Catch user actions with menu
@@ -47,7 +49,6 @@ public:
         init();
     }
 
-    void showAbout();
 
     ~Menu() = default;
     bool run();

--- a/src/domain/interfaces/Menu.hpp
+++ b/src/domain/interfaces/Menu.hpp
@@ -46,6 +46,9 @@ public:
         bg = std::make_unique<sf::Sprite>();
         init();
     }
+
+    void showAbout();
+
     ~Menu() = default;
     bool run();
 };


### PR DESCRIPTION
Feita a about option do menu

Antes que venham me falar algo:
          Não, não ficava legal colocar o github 😞.
          E sim, eu tentei jogar o texto de infoText dentro de um array 👍 e iterar ele em um loop depois ➿,
          mas não, não deu nada certo 😿 , só ficava bugando a tela e dava vontade de morrer.
          E também sim, eu recomendo alguma amigo retirar o `#include <vector>` de menu.cpp 😸 .
          
No mais, se for precisar alterar alguma informação no texto, recomento testar diversas vezes por causa do redimensionamento do texto na tela, e eu achei bem bonitinho a fonte pequenininha, e sim eu achei super legivel 🆗 👌 🧪 !


||


Alteradas algumas conversations, aqui mesmo no github, e espero do fundo do meu coração escurecido que o código compile e rode normal, senão eu vou ☠️ .